### PR TITLE
feature/SendCommand

### DIFF
--- a/Game.Tests/Game.Tests.csproj
+++ b/Game.Tests/Game.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Game.Tests/commands/SendCommandTest.cs
+++ b/Game.Tests/commands/SendCommandTest.cs
@@ -1,0 +1,37 @@
+namespace Game.Tests;
+using Moq;
+using Xunit;
+
+public class SendCommandTests
+{
+    [Fact]
+    public void SendCommand_Should_Call_Receive_On_Success()
+    {
+        var commandMock = new Mock<ICommand>();
+
+        var receiverMock = new Mock<IMessageReceiver>();
+
+        receiverMock.Setup(r => r.CanAccept(It.IsAny<ICommand>())).Returns(true);
+
+        var sendCommand = new SendCommand(commandMock.Object, receiverMock.Object);
+
+        sendCommand.Execute();
+        receiverMock.Verify(r => r.Receive(commandMock.Object), Times.Once);
+    }
+
+    [Fact]
+    public void SendCommand_Should_Throw_Exception_If_Receiver_Cannot_Accept()
+    {
+        var commandMock = new Mock<ICommand>();
+        var receiverMock = new Mock<IMessageReceiver>();
+
+        receiverMock.Setup(r => r.CanAccept(It.IsAny<ICommand>())).Returns(false);
+
+        var sendCommand = new SendCommand(commandMock.Object, receiverMock.Object);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => sendCommand.Execute());
+
+        Assert.Equal("recipient is busy", exception.Message);
+        receiverMock.Verify(r => r.Receive(It.IsAny<ICommand>()), Times.Never);
+    }
+}

--- a/Game.Tests/commands/SendCommandTest.cs
+++ b/Game.Tests/commands/SendCommandTest.cs
@@ -35,4 +35,18 @@ public class SendCommandTests
         Assert.Equal("recipient is busy", exception.Message);
         receiverMock.Verify(r => r.Receive(It.IsAny<ICommand>()), Times.Never);
     }
+
+    [Fact]
+    public void SendCommand_Constructor_Throws_When_Command_Is_Null()
+    {
+        var receiverMock = new Mock<IMessageReceiver>();
+        Assert.Throws<ArgumentNullException>(() => new SendCommand(null, receiverMock.Object));
+    }
+
+    [Fact]
+    public void SendCommand_Constructor_Throws_When_Receiver_Is_Null()
+    {
+        var commandMock = new Mock<ICommand>();
+        Assert.Throws<ArgumentNullException>(() => new SendCommand(commandMock.Object, null));
+    }
 }

--- a/Game.Tests/commands/SendCommandTest.cs
+++ b/Game.Tests/commands/SendCommandTest.cs
@@ -1,4 +1,5 @@
 namespace Game.Tests;
+
 using Moq;
 using Xunit;
 

--- a/Game/Game.csproj
+++ b/Game/Game.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Game/IMassageReciever.cs
+++ b/Game/IMassageReciever.cs
@@ -1,0 +1,7 @@
+namespace Game;
+
+public interface IMessageReceiver
+{
+    public void Receive(ICommand cmd);
+    bool CanAccept(ICommand command);
+}

--- a/Game/commands/SendCommand.cs
+++ b/Game/commands/SendCommand.cs
@@ -11,7 +11,7 @@ public class SendCommand : ICommand
         _receiver = receiver ?? throw new ArgumentNullException(nameof(receiver));
     }
 
-     public void Execute()
+    public void Execute()
     {
         if (!_receiver.CanAccept(_command))
         {

--- a/Game/commands/SendCommand.cs
+++ b/Game/commands/SendCommand.cs
@@ -1,0 +1,23 @@
+namespace Game;
+
+public class SendCommand : ICommand
+{
+    private readonly ICommand _command;
+    private readonly IMessageReceiver _receiver;
+
+    public SendCommand(ICommand command, IMessageReceiver receiver)
+    {
+        _command = command ?? throw new ArgumentNullException(nameof(command));
+        _receiver = receiver ?? throw new ArgumentNullException(nameof(receiver));
+    }
+
+     public void Execute()
+    {
+        if (!_receiver.CanAccept(_command))
+        {
+            throw new InvalidOperationException("recipient is busy");
+        }
+
+        _receiver.Receive(_command);
+    }
+}


### PR DESCRIPTION
SendCommand в конструктор получает команду ICommand и интерфейс ICommandReceiver. В методе Execute SendCommand вызывается метод Receive интерфейса ICommandReceiver, в который передается длительная команда.

Критерии приемки:

Реализован тест "SendCommand передает команду в IMessageReceiver", который проверяет, что при вызове метода Execute класса SendCommand вызывается метод Receive объекта ICommandReceiver с параметром - объектом длительной команды.
Реализован тест, который проверяет, что SendCommand.Execute выбрасывает исключение, если IMessageReceiver не может принять длительную команду.