### PR TITLE
feature/CommandInjectableCommandIoC

### DIFF
--- a/Game.Tests/IoC/CommandInjectableCommandIoCTests.cs
+++ b/Game.Tests/IoC/CommandInjectableCommandIoCTests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+
+namespace Game.Tests.IoC
+{
+    public class RegisterDependencyCommandInjectableCommandTests
+    {
+        public RegisterDependencyCommandInjectableCommandTests()
+        {
+            new InitCommand().Execute();
+            var testScope = Ioc.Resolve<object>("IoC.Scope.Create");
+            Ioc.Resolve<ICommand>("IoC.Scope.Current.Set", testScope).Execute();
+        }
+
+        [Fact]
+        public void Execute_RegistersDependency_ResolvesAsAllRequiredTypes()
+        {
+            new RegisterDependencyCommandInjectableCommand().Execute();
+
+            var asCommand = Ioc.Resolve<ICommand>("Commands.CommandInjectable");
+            var asInjectable = Ioc.Resolve<ICommandInjectable>("Commands.CommandInjectable");
+            var asConcrete = Ioc.Resolve<CommandInjectableCommand>("Commands.CommandInjectable");
+        }
+    }
+}

--- a/Game/IoC/CommandInjectableCommandIoC.cs
+++ b/Game/IoC/CommandInjectableCommandIoC.cs
@@ -1,0 +1,8 @@
+public class RegisterDependencyCommandInjectableCommand : ICommand
+{
+    public void Execute()
+    {
+        Ioc.Resolve<ICommand>("IoC.Register", "Commands.CommandInjectable",
+            (object[] args) => new CommandInjectableCommand()).Execute();
+    }
+}


### PR DESCRIPTION
18. Определить зависимость "Commands.CommandInjectable" в IoC, которая конструирует команду CommandInjectableCommand.
Указание: Для регистрации зависимости определить команду RegisterMacroCommand:

public class RegisterDependencyCommandInjectableCommand : ICommand
{
    public void Execute()
  {
      // код, регистрирующий зависимость
    }
}
Критерии приемки:

Реализован тест, который проверяет, что следующий код работает без выброса исключений:
Ioc.Resolve<ICommand>("Commands.CommadInjectable");
Ioc.Resolve<ICommandInjectable>("Commands.CommadInjectable");
Ioc.Resolve<CommandInjectableCommand>("Commands.CommadInjectable");