### PR TITLE
feature/Actions.StartIoC

### DIFF
--- a/Game.Tests/IoC/Actions.StartIoCTests.cs
+++ b/Game.Tests/IoC/Actions.StartIoCTests.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using Moq;
+using Xunit;
+public class RegisterIoCDependencyActionsStartTests
+{
+    public RegisterIoCDependencyActionsStartTests()
+    {
+        new InitCommand().Execute();
+        var testScope = Ioc.Resolve<object>("IoC.Scope.Create");
+        Ioc.Resolve<ICommand>("IoC.Scope.Current.Set", testScope).Execute();
+        Ioc.Resolve<ICommand>("IoC.Register", "Commands.Macro",
+            (object[] args) => new Mock<ICommand>().Object).Execute();
+    }
+
+    [Fact]
+    public void Execute_RegistersActionsStart_ResolvesSuccessfully()
+    {
+        new RegisterIoCDependencyActionsStart().Execute();
+        var mockOrder = new Mock<IDictionary<string, object>>();
+
+        var actionStart = Ioc.Resolve<ICommand>("Actions.Start", mockOrder.Object);
+
+        Assert.NotNull(actionStart);
+        Assert.IsAssignableFrom<ICommand>(actionStart);
+    }
+}

--- a/Game/IoC/Actions.StartIoC.cs
+++ b/Game/IoC/Actions.StartIoC.cs
@@ -1,0 +1,9 @@
+public class RegisterIoCDependencyActionsStart : ICommand
+{
+    public void Execute()
+    {
+        Ioc.Resolve<ICommand>("IoC.Register", "Actions.Start",
+            (object[] args) => Ioc.Resolve<ICommand>("Commands.Macro", args[0])
+        ).Execute();
+    }
+}


### PR DESCRIPTION
Необходимо так определить зависимость, чтобы следующий код позволял получать команду:

IDictionary<string, object> order = ...; // приказ о старте длительной операции
Ioc.Resolve<ICommand>("Actions.Start", order);
Сама регистрация зависимости должна быть выполнена в команде RegisterIoCDepenedncyActionsStart

public class RegisterIoCDependencyActionsStart : ICommand
{
    public void Execute()
  {
    // здесь код для регистрации зависимостей
  }
}
Примечание: Все дополнительные зависимости, которые будут использованы при реализации, кроме зависимостей, которые были оговорены выше, должны быть также зарегистрированы.

Критерии приемки:

Реализован тест, который проверяет, что при выполнении Execute класса RegisterIoCDependencyActionsStart зависимость разрешается.