### PR TITLE
feature/Actions.StopIoC

### DIFF
--- a/Game.Tests/IoC/Actions.StopIoCTests.cs
+++ b/Game.Tests/IoC/Actions.StopIoCTests.cs
@@ -16,14 +16,13 @@ namespace Game.Tests.IoC
         [Fact]
         public void Execute_RegistersActionsStop_ResolvesSuccessfully()
         {
-            // Arrange
             new RegisterIoCDependencyActionsStop().Execute();
             var mockOrder = new Mock<IDictionary<string, object>>();
 
-            // Act
-            var actionStop = Ioc.Resolve<ICommand>("Actions.Stop", mockOrder.Object);
 
-            // Assert
+            var actionStop = Ioc.Resolve<ICommand>("Actions.Stop", mockOrder.Object);
+            actionStop.Execute();
+
             Assert.NotNull(actionStop);
             Assert.IsType<EmptyCommand>(actionStop);
         }

--- a/Game.Tests/IoC/Actions.StopIoCTests.cs
+++ b/Game.Tests/IoC/Actions.StopIoCTests.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Moq;
+using Xunit;
+
+namespace Game.Tests.IoC
+{
+    public class RegisterIoCDependencyActionsStopTests
+    {
+        public RegisterIoCDependencyActionsStopTests()
+        {
+            new InitCommand().Execute();
+            var testScope = Ioc.Resolve<object>("IoC.Scope.Create");
+            Ioc.Resolve<ICommand>("IoC.Scope.Current.Set", testScope).Execute();
+        }
+
+        [Fact]
+        public void Execute_RegistersActionsStop_ResolvesSuccessfully()
+        {
+            // Arrange
+            new RegisterIoCDependencyActionsStop().Execute();
+            var mockOrder = new Mock<IDictionary<string, object>>();
+
+            // Act
+            var actionStop = Ioc.Resolve<ICommand>("Actions.Stop", mockOrder.Object);
+
+            // Assert
+            Assert.NotNull(actionStop);
+            Assert.IsType<EmptyCommand>(actionStop);
+        }
+    }
+}

--- a/Game/IoC/Actions.StopIoC.cs
+++ b/Game/IoC/Actions.StopIoC.cs
@@ -1,0 +1,9 @@
+public class RegisterIoCDependencyActionsStop : ICommand
+{
+    public void Execute()
+    {
+        Ioc.Resolve<ICommand>("IoC.Register", "Actions.Stop",
+            (object[] args) => new EmptyCommand()
+        ).Execute();
+    }
+}

--- a/Game/commands/EmptyCommand.cs
+++ b/Game/commands/EmptyCommand.cs
@@ -1,0 +1,4 @@
+public class EmptyCommand : ICommand
+{
+    public void Execute() { }
+}


### PR DESCRIPTION
20. Определить зависимость "Actions.Stop" для запуска длительной операции.
Необходимо так определить зависимость, чтобы следующий код позволял получать команду:

IDictionary<string, object> order = ...; // приказ об остановке длительной операции
Ioc.Resolve<ICommand>("Actions.Stop", order);
Сама регистрация зависимости должна быть выполнена в команде RegisterIoCDepenedncyActionsStop

public class RegisterIoCDependencyActionsStop : ICommand
{
    public void Execute()
  {
    // здесь код для регистрации зависимостей
  }
}
Критерии приемки:

Реализован тест, который проверяет, что при выполнении Execute класса RegisterIoCDependencyActionsStop зависимость разрешается.
Остановка команды выполняется за константное время.