### PR TITLE
Featurenew/command injectable command

### DIFF
--- a/Game.Tests/Game.Tests.csproj
+++ b/Game.Tests/Game.Tests.csproj
@@ -13,6 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/Game.Tests/commands/CommandInjectableCommandTests.cs
+++ b/Game.Tests/commands/CommandInjectableCommandTests.cs
@@ -8,25 +8,19 @@ namespace Game.Tests
         [Fact]
         public void Execute_InvokesInjectedCommand()
         {
-            // Arrange
             var mockCommand = new Mock<ICommand>();
             var injectable = new CommandInjectableCommand();
 
-            // Act: Внедряем команду и выполняем
             injectable.Inject(mockCommand.Object);
             injectable.Execute();
-
-            // Assert: Проверяем, что внедрённая команда была вызвана ровно 1 раз
+            
             mockCommand.Verify(c => c.Execute(), Times.Once);
         }
 
         [Fact]
         public void Execute_ThrowsException_WhenCommandNotInjected()
         {
-            // Arrange
             var injectable = new CommandInjectableCommand();
-
-            // Act & Assert: Execute без Inject должен выбросить исключение
             var ex = Assert.Throws<NullReferenceException>(() => injectable.Execute());
         }
     }

--- a/Game.Tests/commands/CommandInjectableCommandTests.cs
+++ b/Game.Tests/commands/CommandInjectableCommandTests.cs
@@ -1,0 +1,33 @@
+using Moq;
+using Xunit;
+
+namespace Game.Tests
+{
+    public class CommandInjectableCommandTests
+    {
+        [Fact]
+        public void Execute_InvokesInjectedCommand()
+        {
+            // Arrange
+            var mockCommand = new Mock<ICommand>();
+            var injectable = new CommandInjectableCommand();
+
+            // Act: Внедряем команду и выполняем
+            injectable.Inject(mockCommand.Object);
+            injectable.Execute();
+
+            // Assert: Проверяем, что внедрённая команда была вызвана ровно 1 раз
+            mockCommand.Verify(c => c.Execute(), Times.Once);
+        }
+
+        [Fact]
+        public void Execute_ThrowsException_WhenCommandNotInjected()
+        {
+            // Arrange
+            var injectable = new CommandInjectableCommand();
+
+            // Act & Assert: Execute без Inject должен выбросить исключение
+            var ex = Assert.Throws<NullReferenceException>(() => injectable.Execute());
+        }
+    }
+}

--- a/Game.Tests/commands/CommandInjectableCommandTests.cs
+++ b/Game.Tests/commands/CommandInjectableCommandTests.cs
@@ -13,7 +13,7 @@ namespace Game.Tests
 
             injectable.Inject(mockCommand.Object);
             injectable.Execute();
-            
+
             mockCommand.Verify(c => c.Execute(), Times.Once);
         }
 

--- a/Game/commands/CommandInjectableCommand.cs
+++ b/Game/commands/CommandInjectableCommand.cs
@@ -1,0 +1,14 @@
+public class CommandInjectableCommand : ICommand, ICommandInjectable
+{
+    private ICommand _injectedCommand;
+
+    public void Inject(ICommand command)
+    {
+        _injectedCommand = command;
+    }
+
+    public void Execute()
+    {
+        _injectedCommand.Execute();
+    }
+}


### PR DESCRIPTION
Определить команду CommandInjectableCommand
Команда реализует два интерфейса ICommand и ICommandIjectable.
Критерии приемки:

Реализован тест, который проверяет, что после того как команда будет внедрена в объект класса CommandInjectableCommand, то она будет вызвана при выполнении метода Execute объекта класса CommandInjectableCommand.
Реализован тест, который проверяет, что вызов Execute класса CommandInjectableCommand выбрасывает исключение, если не была внедерена команда.