### PR TITLE
Featurenew/macro command io c

### DIFF
--- a/Game.Tests/Game.Tests.csproj
+++ b/Game.Tests/Game.Tests.csproj
@@ -15,7 +15,6 @@
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/Game.Tests/Game.Tests.csproj
+++ b/Game.Tests/Game.Tests.csproj
@@ -15,6 +15,7 @@
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/Game.Tests/IoC/RegisterIoCDependencyMacroCommandTests.cs
+++ b/Game.Tests/IoC/RegisterIoCDependencyMacroCommandTests.cs
@@ -18,7 +18,7 @@ public class RegisterIoCDependencyMacroCommandTests
         var mockCommand2 = new Mock<ICommand>().Object;
 
         var commandsToExecute = new ICommand[] { mockCommand1, mockCommand2 };
-        
+
         var registerMacroCmd = new RegisterIoCDependencyMacroCommand();
 
         registerMacroCmd.Execute();

--- a/Game.Tests/IoC/RegisterIoCDependencyMacroCommandTests.cs
+++ b/Game.Tests/IoC/RegisterIoCDependencyMacroCommandTests.cs
@@ -1,0 +1,31 @@
+using Game;
+using Xunit;
+using Moq;
+
+public class RegisterIoCDependencyMacroCommandTests
+{
+    public RegisterIoCDependencyMacroCommandTests()
+    {
+        new InitCommand().Execute();
+        var testScope = Ioc.Resolve<object>("IoC.Scope.Create");
+        Ioc.Resolve<ICommand>("IoC.Scope.Current.Set", testScope).Execute();
+    }
+
+    [Fact]
+    public void Execute_Should_Register_MacroCommand_Dependency()
+    {
+        var mockCommand1 = new Mock<ICommand>().Object;
+        var mockCommand2 = new Mock<ICommand>().Object;
+
+        var commandsToExecute = new ICommand[] { mockCommand1, mockCommand2 };
+        
+        var registerMacroCmd = new RegisterIoCDependencyMacroCommand();
+
+        registerMacroCmd.Execute();
+
+        var resolvedMacroCommand = Ioc.Resolve<ICommand>("Commands.Macro", new object[] { commandsToExecute });
+
+        Assert.NotNull(resolvedMacroCommand);
+        Assert.IsType<MacroCommand>(resolvedMacroCommand);
+    }
+}

--- a/Game.Tests/commands/MacroCommandTest.cs
+++ b/Game.Tests/commands/MacroCommandTest.cs
@@ -1,0 +1,46 @@
+using Xunit;
+using System;
+using Moq;
+using Game;
+
+namespace Game.Tests;
+
+public class MacroCommandTests()
+{
+    [Fact]
+    public void MacroCommand_ExecutesAllCommands()
+    {
+        var cmd1 = new Mock<ICommand>();
+        var cmd2 = new Mock<ICommand>();
+
+        var macro = new MacroCommand(new[] { cmd1.Object, cmd2.Object });
+
+        macro.Execute();
+
+        cmd1.Verify(c => c.Execute(), Times.Once);
+        cmd2.Verify(c => c.Execute(), Times.Once);
+    }
+
+    [Fact]
+    public void MacroCommand_ThrowsException_AndStopsExecution()
+    {
+        var cmd1 = new Mock<ICommand>();
+        var cmdException = new Mock<ICommand>();
+        var cmd2 = new Mock<ICommand>();
+
+        cmdException.Setup(c => c.Execute()).Throws<Exception>();
+
+        var macro = new MacroCommand(new[]
+        {
+            cmd1.Object,
+            cmdException.Object,
+            cmd2.Object
+        });
+
+        Assert.Throws<Exception>(() => macro.Execute());
+
+        cmd1.Verify(c => c.Execute(), Times.Once);
+        cmdException.Verify(c => c.Execute(), Times.Once);
+        cmd2.Verify(c => c.Execute(), Times.Never);
+    }
+}

--- a/Game/IoC/RegisterIoCDependencyMacroCommand.cs
+++ b/Game/IoC/RegisterIoCDependencyMacroCommand.cs
@@ -1,0 +1,23 @@
+using App;
+using App.Scopes;
+
+public class RegisterIoCDependencyMacroCommand : ICommand
+{
+    public void Execute()
+    {
+        Func<object[], object> strategy = (object[] args) =>
+        {
+            var commands = (ICommand[])args[0];
+
+            return new MacroCommand(commands);
+        };
+
+        var registerCommand = Ioc.Resolve<ICommand>(
+            "IoC.Register",
+            "Commands.Macro",
+            strategy
+        );
+
+        registerCommand.Execute();
+    }
+}

--- a/Game/commands/MacroCommand.cs
+++ b/Game/commands/MacroCommand.cs
@@ -1,0 +1,14 @@
+public class MacroCommand : ICommand
+{
+    private readonly ICommand[] _commands;
+
+    public MacroCommand(ICommand[] commands)
+    {
+        _commands = commands;
+    }
+
+    public void Execute()
+    {
+        _commands.ToList().ForEach(c => c.Execute());
+    }
+}


### PR DESCRIPTION
Указание: Для регистрации зависимости определить команду RegisterIoCDependencyMacroCommand:

public class RegisterIoCDependencyMacroCommand : ICommand
{
public void Execute()
{
// код, регистрирующий зависимость
}
}
Критерии приемки:

Реализован тест, который проверяет, что при выполнении Execute класса RegisterDependencyMacroCommand зависимость разрешается.

Выполнил: Мазунин Даниил