### PR TITLE
Featurenew/macro command io c

### DIFF
--- a/Game.Tests/IoC/RegisterIoCDependencyMacroCommandTests.cs
+++ b/Game.Tests/IoC/RegisterIoCDependencyMacroCommandTests.cs
@@ -18,7 +18,7 @@ public class RegisterIoCDependencyMacroCommandTests
         var mockCommand2 = new Mock<ICommand>().Object;
 
         var commandsToExecute = new ICommand[] { mockCommand1, mockCommand2 };
-        
+
         var registerMacroCmd = new RegisterIoCDependencyMacroCommand();
 
         registerMacroCmd.Execute();

--- a/Game.Tests/IoC/RegisterIoCDependencyMacroCommandTests.cs
+++ b/Game.Tests/IoC/RegisterIoCDependencyMacroCommandTests.cs
@@ -1,0 +1,31 @@
+using Game;
+using Xunit;
+using Moq;
+
+public class RegisterIoCDependencyMacroCommandTests
+{
+    public RegisterIoCDependencyMacroCommandTests()
+    {
+        new InitCommand().Execute();
+        var testScope = Ioc.Resolve<object>("IoC.Scope.Create");
+        Ioc.Resolve<ICommand>("IoC.Scope.Current.Set", testScope).Execute();
+    }
+
+    [Fact]
+    public void Execute_Should_Register_MacroCommand_Dependency()
+    {
+        var mockCommand1 = new Mock<ICommand>().Object;
+        var mockCommand2 = new Mock<ICommand>().Object;
+
+        var commandsToExecute = new ICommand[] { mockCommand1, mockCommand2 };
+        
+        var registerMacroCmd = new RegisterIoCDependencyMacroCommand();
+
+        registerMacroCmd.Execute();
+
+        var resolvedMacroCommand = Ioc.Resolve<ICommand>("Commands.Macro", new object[] { commandsToExecute });
+
+        Assert.NotNull(resolvedMacroCommand);
+        Assert.IsType<MacroCommand>(resolvedMacroCommand);
+    }
+}

--- a/Game/IoC/RegisterIoCDependencyMacroCommand.cs
+++ b/Game/IoC/RegisterIoCDependencyMacroCommand.cs
@@ -1,0 +1,23 @@
+using App;
+using App.Scopes;
+
+public class RegisterIoCDependencyMacroCommand : ICommand
+{
+    public void Execute()
+    {
+        Func<object[], object> strategy = (object[] args) =>
+        {
+            var commands = (ICommand[])args[0];
+
+            return new MacroCommand(commands);
+        };
+
+        var registerCommand = Ioc.Resolve<ICommand>(
+            "IoC.Register",
+            "Commands.Macro",
+            strategy
+        );
+
+        registerCommand.Execute();
+    }
+}


### PR DESCRIPTION
Указание: Для регистрации зависимости определить команду RegisterIoCDependencyMacroCommand:

public class RegisterIoCDependencyMacroCommand : ICommand
{
public void Execute()
{
// код, регистрирующий зависимость
}
}
Критерии приемки:

Реализован тест, который проверяет, что при выполнении Execute класса RegisterDependencyMacroCommand зависимость разрешается.

Выполнил: Мазунин Даниил