### PR TITLE
Featurenew/move io c

### DIFF
--- a/Game.Tests/IoC/RegisterIoCDependencyMoveCommandTests.cs
+++ b/Game.Tests/IoC/RegisterIoCDependencyMoveCommandTests.cs
@@ -1,0 +1,34 @@
+using Game;
+using Xunit;
+using Moq;
+
+public class RegisterIoCDependencyMoveCommandTests
+{
+    public RegisterIoCDependencyMoveCommandTests()
+    {
+        new InitCommand().Execute();
+        var testScope = Ioc.Resolve<object>("IoC.Scope.Create");
+        Ioc.Resolve<ICommand>("IoC.Scope.Current.Set", testScope).Execute();
+    }
+
+    [Fact]
+    public void Execute_Should_Register_MoveCommand_Dependency()
+    {
+        var mockGameObject = new Mock<object>().Object;
+        var mockMovingObject = new Mock<IMovingObject>().Object;
+        Ioc.Resolve<ICommand>(
+            "IoC.Register",
+            "Adapters.IMovingObject",
+            (object[] _) => mockMovingObject
+        ).Execute();
+
+        var registerCmd = new RegisterIoCDependencyMoveCommand();
+
+        registerCmd.Execute();
+
+        var resolvedCommand = Ioc.Resolve<ICommand>("Commands.Move", mockGameObject);
+
+        Assert.NotNull(resolvedCommand);
+        Assert.IsType<MoveCommand>(resolvedCommand);
+    }
+}

--- a/Game/IoC/RegisterIoCDependencyMoveCommand.cs
+++ b/Game/IoC/RegisterIoCDependencyMoveCommand.cs
@@ -1,0 +1,26 @@
+using App;
+using App.Scopes;
+using Game;
+
+public class RegisterIoCDependencyMoveCommand : ICommand
+{
+    public void Execute()
+    {
+        Func<object[], object> strategy = (object[] args) =>
+        {
+            var obj = args[0];
+
+            var adapter = Ioc.Resolve<object>("Adapters.IMovingObject", obj);
+            
+            return new MoveCommand((IMovingObject)adapter);
+        };
+
+        var registerCommand = Ioc.Resolve<ICommand>(
+            "IoC.Register",
+            "Commands.Move",
+            strategy
+        );
+
+        registerCommand.Execute();
+    }
+}

--- a/Game/IoC/RegisterIoCDependencyMoveCommand.cs
+++ b/Game/IoC/RegisterIoCDependencyMoveCommand.cs
@@ -11,7 +11,7 @@ public class RegisterIoCDependencyMoveCommand : ICommand
             var obj = args[0];
 
             var adapter = Ioc.Resolve<object>("Adapters.IMovingObject", obj);
-            
+
             return new MoveCommand((IMovingObject)adapter);
         };
 


### PR DESCRIPTION
6. Регистрация зависимости Commands.Move в IoC.
Зарегистрировать зависимость "Commands.Move" в IoC, с помощью которой можно разрешить команду MoveCommand по игровому объекту. Для регистрации зависимости определить отдельную команду с префиксом RegisterIoCDependency:

public class RegisterIoCDependencyMoveCommand : ICommand
{
    public void Execute()
  {
      // код, регистрирующий зависимость
    }
}
Примечание: Для того, чтобы создать MoveCommand, необходимо создать адаптер IDictionary<string, object> для интерфейса IMovingObject. Задача конструирования Адаптеров по интерфейсу будет рассмотрена в другой лабораторной работе, поэтому в данной задаче используйте разрешение зависимости Ioc.Resolve("Adapters.IMovingObject", obj), где obj - игровой объект. В тестах используйте Mock-объекты, для разрешения этой зависимости.

Критерии приемки:

Реализован тест, который проверяет, что при выполнении Execute класса RegisterIoCDependencyMoveCommand зависимость разрешается.

Выполняет: Меженов Егор