### PR TITLE
feature/Actions.StopIoC

### DIFF
--- a/Game.Tests/Game.Tests.csproj
+++ b/Game.Tests/Game.Tests.csproj
@@ -13,6 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/Game.Tests/IoC/Actions.StartIoCTests.cs
+++ b/Game.Tests/IoC/Actions.StartIoCTests.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using Moq;
+using Xunit;
+public class RegisterIoCDependencyActionsStartTests
+{
+    public RegisterIoCDependencyActionsStartTests()
+    {
+        new InitCommand().Execute();
+        var testScope = Ioc.Resolve<object>("IoC.Scope.Create");
+        Ioc.Resolve<ICommand>("IoC.Scope.Current.Set", testScope).Execute();
+        Ioc.Resolve<ICommand>("IoC.Register", "Commands.Macro",
+            (object[] args) => new Mock<ICommand>().Object).Execute();
+    }
+
+    [Fact]
+    public void Execute_RegistersActionsStart_ResolvesSuccessfully()
+    {
+        new RegisterIoCDependencyActionsStart().Execute();
+        var mockOrder = new Mock<IDictionary<string, object>>();
+
+        var actionStart = Ioc.Resolve<ICommand>("Actions.Start", mockOrder.Object);
+
+        Assert.NotNull(actionStart);
+        Assert.IsAssignableFrom<ICommand>(actionStart);
+    }
+}

--- a/Game.Tests/IoC/Actions.StopIoCTests.cs
+++ b/Game.Tests/IoC/Actions.StopIoCTests.cs
@@ -16,14 +16,13 @@ namespace Game.Tests.IoC
         [Fact]
         public void Execute_RegistersActionsStop_ResolvesSuccessfully()
         {
-            // Arrange
             new RegisterIoCDependencyActionsStop().Execute();
             var mockOrder = new Mock<IDictionary<string, object>>();
 
-            // Act
-            var actionStop = Ioc.Resolve<ICommand>("Actions.Stop", mockOrder.Object);
 
-            // Assert
+            var actionStop = Ioc.Resolve<ICommand>("Actions.Stop", mockOrder.Object);
+            actionStop.Execute();
+
             Assert.NotNull(actionStop);
             Assert.IsType<EmptyCommand>(actionStop);
         }

--- a/Game.Tests/IoC/Actions.StopIoCTests.cs
+++ b/Game.Tests/IoC/Actions.StopIoCTests.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Moq;
+using Xunit;
+
+namespace Game.Tests.IoC
+{
+    public class RegisterIoCDependencyActionsStopTests
+    {
+        public RegisterIoCDependencyActionsStopTests()
+        {
+            new InitCommand().Execute();
+            var testScope = Ioc.Resolve<object>("IoC.Scope.Create");
+            Ioc.Resolve<ICommand>("IoC.Scope.Current.Set", testScope).Execute();
+        }
+
+        [Fact]
+        public void Execute_RegistersActionsStop_ResolvesSuccessfully()
+        {
+            // Arrange
+            new RegisterIoCDependencyActionsStop().Execute();
+            var mockOrder = new Mock<IDictionary<string, object>>();
+
+            // Act
+            var actionStop = Ioc.Resolve<ICommand>("Actions.Stop", mockOrder.Object);
+
+            // Assert
+            Assert.NotNull(actionStop);
+            Assert.IsType<EmptyCommand>(actionStop);
+        }
+    }
+}

--- a/Game.Tests/IoC/CommandInjectableCommandIoCTests.cs
+++ b/Game.Tests/IoC/CommandInjectableCommandIoCTests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+
+namespace Game.Tests.IoC
+{
+    public class RegisterDependencyCommandInjectableCommandTests
+    {
+        public RegisterDependencyCommandInjectableCommandTests()
+        {
+            new InitCommand().Execute();
+            var testScope = Ioc.Resolve<object>("IoC.Scope.Create");
+            Ioc.Resolve<ICommand>("IoC.Scope.Current.Set", testScope).Execute();
+        }
+
+        [Fact]
+        public void Execute_RegistersDependency_ResolvesAsAllRequiredTypes()
+        {
+            new RegisterDependencyCommandInjectableCommand().Execute();
+
+            var asCommand = Ioc.Resolve<ICommand>("Commands.CommandInjectable");
+            var asInjectable = Ioc.Resolve<ICommandInjectable>("Commands.CommandInjectable");
+            var asConcrete = Ioc.Resolve<CommandInjectableCommand>("Commands.CommandInjectable");
+        }
+    }
+}

--- a/Game.Tests/commands/CommandInjectableCommandTests.cs
+++ b/Game.Tests/commands/CommandInjectableCommandTests.cs
@@ -8,25 +8,19 @@ namespace Game.Tests
         [Fact]
         public void Execute_InvokesInjectedCommand()
         {
-            // Arrange
             var mockCommand = new Mock<ICommand>();
             var injectable = new CommandInjectableCommand();
 
-            // Act: Внедряем команду и выполняем
             injectable.Inject(mockCommand.Object);
             injectable.Execute();
-
-            // Assert: Проверяем, что внедрённая команда была вызвана ровно 1 раз
+            
             mockCommand.Verify(c => c.Execute(), Times.Once);
         }
 
         [Fact]
         public void Execute_ThrowsException_WhenCommandNotInjected()
         {
-            // Arrange
             var injectable = new CommandInjectableCommand();
-
-            // Act & Assert: Execute без Inject должен выбросить исключение
             var ex = Assert.Throws<NullReferenceException>(() => injectable.Execute());
         }
     }

--- a/Game.Tests/commands/CommandInjectableCommandTests.cs
+++ b/Game.Tests/commands/CommandInjectableCommandTests.cs
@@ -1,0 +1,33 @@
+using Moq;
+using Xunit;
+
+namespace Game.Tests
+{
+    public class CommandInjectableCommandTests
+    {
+        [Fact]
+        public void Execute_InvokesInjectedCommand()
+        {
+            // Arrange
+            var mockCommand = new Mock<ICommand>();
+            var injectable = new CommandInjectableCommand();
+
+            // Act: Внедряем команду и выполняем
+            injectable.Inject(mockCommand.Object);
+            injectable.Execute();
+
+            // Assert: Проверяем, что внедрённая команда была вызвана ровно 1 раз
+            mockCommand.Verify(c => c.Execute(), Times.Once);
+        }
+
+        [Fact]
+        public void Execute_ThrowsException_WhenCommandNotInjected()
+        {
+            // Arrange
+            var injectable = new CommandInjectableCommand();
+
+            // Act & Assert: Execute без Inject должен выбросить исключение
+            var ex = Assert.Throws<NullReferenceException>(() => injectable.Execute());
+        }
+    }
+}

--- a/Game.Tests/commands/CommandInjectableCommandTests.cs
+++ b/Game.Tests/commands/CommandInjectableCommandTests.cs
@@ -13,7 +13,7 @@ namespace Game.Tests
 
             injectable.Inject(mockCommand.Object);
             injectable.Execute();
-            
+
             mockCommand.Verify(c => c.Execute(), Times.Once);
         }
 

--- a/Game/ICommandInjectable.cs
+++ b/Game/ICommandInjectable.cs
@@ -1,0 +1,4 @@
+public interface ICommandInjectable
+{
+    void Inject(ICommand command);
+}

--- a/Game/IoC/Actions.StartIoC.cs
+++ b/Game/IoC/Actions.StartIoC.cs
@@ -1,0 +1,9 @@
+public class RegisterIoCDependencyActionsStart : ICommand
+{
+    public void Execute()
+    {
+        Ioc.Resolve<ICommand>("IoC.Register", "Actions.Start",
+            (object[] args) => Ioc.Resolve<ICommand>("Commands.Macro", args[0])
+        ).Execute();
+    }
+}

--- a/Game/IoC/Actions.StopIoC.cs
+++ b/Game/IoC/Actions.StopIoC.cs
@@ -1,0 +1,9 @@
+public class RegisterIoCDependencyActionsStop : ICommand
+{
+    public void Execute()
+    {
+        Ioc.Resolve<ICommand>("IoC.Register", "Actions.Stop",
+            (object[] args) => new EmptyCommand()
+        ).Execute();
+    }
+}

--- a/Game/IoC/CommandInjectableCommandIoC.cs
+++ b/Game/IoC/CommandInjectableCommandIoC.cs
@@ -1,0 +1,8 @@
+public class RegisterDependencyCommandInjectableCommand : ICommand
+{
+    public void Execute()
+    {
+        Ioc.Resolve<ICommand>("IoC.Register", "Commands.CommandInjectable",
+            (object[] args) => new CommandInjectableCommand()).Execute();
+    }
+}

--- a/Game/commands/CommandInjectableCommand.cs
+++ b/Game/commands/CommandInjectableCommand.cs
@@ -1,0 +1,14 @@
+public class CommandInjectableCommand : ICommand, ICommandInjectable
+{
+    private ICommand _injectedCommand;
+
+    public void Inject(ICommand command)
+    {
+        _injectedCommand = command;
+    }
+
+    public void Execute()
+    {
+        _injectedCommand.Execute();
+    }
+}

--- a/Game/commands/EmptyCommand.cs
+++ b/Game/commands/EmptyCommand.cs
@@ -1,0 +1,4 @@
+public class EmptyCommand : ICommand
+{
+    public void Execute() { }
+}


### PR DESCRIPTION
20. Определить зависимость "Actions.Stop" для запуска длительной операции.
Необходимо так определить зависимость, чтобы следующий код позволял получать команду:
IDictionary<string, object> order = ...; // приказ об остановке длительной операции
Ioc.Resolve("Actions.Stop", order);
Сама регистрация зависимости должна быть выполнена в команде RegisterIoCDepenedncyActionsStop
public class RegisterIoCDependencyActionsStop : ICommand
{
public void Execute()
{
// здесь код для регистрации зависимостей
}
}

Критерии приемки:
Реализован тест, который проверяет, что при выполнении Execute класса RegisterIoCDependencyActionsStop зависимость разрешается.
Остановка команды выполняется за константное время.