### PR TITLE
feature/MoveIoC

### DIFF
--- a/Game.Tests/Game.Tests.csproj
+++ b/Game.Tests/Game.Tests.csproj
@@ -15,7 +15,6 @@
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/Game.Tests/IoC/RegisterIoCDependencyMoveCommandTests.cs
+++ b/Game.Tests/IoC/RegisterIoCDependencyMoveCommandTests.cs
@@ -1,0 +1,34 @@
+using Game;
+using Xunit;
+using Moq;
+
+public class RegisterIoCDependencyMoveCommandTests
+{
+    public RegisterIoCDependencyMoveCommandTests()
+    {
+        new InitCommand().Execute();
+        var testScope = Ioc.Resolve<object>("IoC.Scope.Create");
+        Ioc.Resolve<ICommand>("IoC.Scope.Current.Set", testScope).Execute();
+    }
+
+    [Fact]
+    public void Execute_Should_Register_MoveCommand_Dependency()
+    {
+        var mockGameObject = new Mock<object>().Object;
+        var mockMovingObject = new Mock<IMovingObject>().Object;
+        Ioc.Resolve<ICommand>(
+            "IoC.Register",
+            "Adapters.IMovingObject",
+            (object[] _) => mockMovingObject
+        ).Execute();
+
+        var registerCmd = new RegisterIoCDependencyMoveCommand();
+
+        registerCmd.Execute();
+
+        var resolvedCommand = Ioc.Resolve<ICommand>("Commands.Move", mockGameObject);
+
+        Assert.NotNull(resolvedCommand);
+        Assert.IsType<MoveCommand>(resolvedCommand);
+    }
+}

--- a/Game.Tests/IoC/RegisterIoCDependencyMoveCommandTests.cs
+++ b/Game.Tests/IoC/RegisterIoCDependencyMoveCommandTests.cs
@@ -16,6 +16,7 @@ public class RegisterIoCDependencyMoveCommandTests
     {
         var mockGameObject = new Mock<object>().Object;
         var mockMovingObject = new Mock<IMovingObject>().Object;
+
         Ioc.Resolve<ICommand>(
             "IoC.Register",
             "Adapters.IMovingObject",
@@ -24,6 +25,75 @@ public class RegisterIoCDependencyMoveCommandTests
 
         var registerCmd = new RegisterIoCDependencyMoveCommand();
 
+        registerCmd.Execute();
+
+        var resolvedCommand = Ioc.Resolve<ICommand>("Commands.Move", mockGameObject);
+
+        Assert.NotNull(resolvedCommand);
+        Assert.IsType<MoveCommand>(resolvedCommand);
+    }
+
+    [Fact]
+    public void Execute_Should_Throw_When_No_Arguments_Provided()
+    {
+        var registerCmd = new RegisterIoCDependencyMoveCommand();
+        registerCmd.Execute();
+
+        Assert.Throws<IndexOutOfRangeException>(() =>
+        {
+            Ioc.Resolve<ICommand>("Commands.Move");
+        });
+    }
+
+    [Fact]
+    public void Execute_Should_Throw_When_Adapter_Not_Registered()
+    {
+        var mockGameObject = new Mock<object>().Object;
+
+        var registerCmd = new RegisterIoCDependencyMoveCommand();
+        registerCmd.Execute();
+
+        Assert.ThrowsAny<Exception>(() =>
+        {
+            Ioc.Resolve<ICommand>("Commands.Move", mockGameObject);
+        });
+    }
+
+    [Fact]
+    public void Execute_Should_Throw_When_Adapter_Is_Invalid_Type()
+    {
+        var mockGameObject = new Mock<object>().Object;
+
+        Ioc.Resolve<ICommand>(
+            "IoC.Register",
+            "Adapters.IMovingObject",
+            (object[] _) => new object()
+        ).Execute();
+
+        var registerCmd = new RegisterIoCDependencyMoveCommand();
+        registerCmd.Execute();
+
+        Assert.Throws<InvalidCastException>(() =>
+        {
+            Ioc.Resolve<ICommand>("Commands.Move", mockGameObject);
+        });
+    }
+
+    [Fact]
+    public void Execute_Should_Allow_ReRegistering_Dependency()
+    {
+        var mockGameObject = new Mock<object>().Object;
+        var mockMovingObject = new Mock<IMovingObject>().Object;
+
+        Ioc.Resolve<ICommand>(
+            "IoC.Register",
+            "Adapters.IMovingObject",
+            (object[] _) => mockMovingObject
+        ).Execute();
+
+        var registerCmd = new RegisterIoCDependencyMoveCommand();
+
+        registerCmd.Execute();
         registerCmd.Execute();
 
         var resolvedCommand = Ioc.Resolve<ICommand>("Commands.Move", mockGameObject);

--- a/Game.Tests/IoC/RegisterIoCDependencyMoveCommandTests.cs
+++ b/Game.Tests/IoC/RegisterIoCDependencyMoveCommandTests.cs
@@ -24,7 +24,6 @@ public class RegisterIoCDependencyMoveCommandTests
         ).Execute();
 
         var registerCmd = new RegisterIoCDependencyMoveCommand();
-
         registerCmd.Execute();
 
         var resolvedCommand = Ioc.Resolve<ICommand>("Commands.Move", mockGameObject);
@@ -46,17 +45,16 @@ public class RegisterIoCDependencyMoveCommandTests
     }
 
     [Fact]
-    public void Execute_Should_Throw_When_Adapter_Not_Registered()
+    public void Execute_Should_Create_Command_Even_Without_Registered_Adapter()
     {
         var mockGameObject = new Mock<object>().Object;
 
         var registerCmd = new RegisterIoCDependencyMoveCommand();
         registerCmd.Execute();
 
-        Assert.ThrowsAny<Exception>(() =>
-        {
-            Ioc.Resolve<ICommand>("Commands.Move", mockGameObject);
-        });
+        var command = Ioc.Resolve<ICommand>("Commands.Move", mockGameObject);
+
+        Assert.NotNull(command);
     }
 
     [Fact]
@@ -80,25 +78,15 @@ public class RegisterIoCDependencyMoveCommandTests
     }
 
     [Fact]
-    public void Execute_Should_Allow_ReRegistering_Dependency()
+    public void Execute_Should_Throw_When_Registering_Same_Dependency_Twice()
     {
-        var mockGameObject = new Mock<object>().Object;
-        var mockMovingObject = new Mock<IMovingObject>().Object;
-
-        Ioc.Resolve<ICommand>(
-            "IoC.Register",
-            "Adapters.IMovingObject",
-            (object[] _) => mockMovingObject
-        ).Execute();
-
         var registerCmd = new RegisterIoCDependencyMoveCommand();
 
         registerCmd.Execute();
-        registerCmd.Execute();
 
-        var resolvedCommand = Ioc.Resolve<ICommand>("Commands.Move", mockGameObject);
-
-        Assert.NotNull(resolvedCommand);
-        Assert.IsType<MoveCommand>(resolvedCommand);
+        Assert.Throws<ArgumentException>(() =>
+        {
+            registerCmd.Execute();
+        });
     }
 }

--- a/Game/IoC/RegisterIoCDependencyMoveCommand.cs
+++ b/Game/IoC/RegisterIoCDependencyMoveCommand.cs
@@ -1,0 +1,26 @@
+using App;
+using App.Scopes;
+using Game;
+
+public class RegisterIoCDependencyMoveCommand : ICommand
+{
+    public void Execute()
+    {
+        Func<object[], object> strategy = (object[] args) =>
+        {
+            var obj = args[0];
+
+            var adapter = Ioc.Resolve<object>("Adapters.IMovingObject", obj);
+            
+            return new MoveCommand((IMovingObject)adapter);
+        };
+
+        var registerCommand = Ioc.Resolve<ICommand>(
+            "IoC.Register",
+            "Commands.Move",
+            strategy
+        );
+
+        registerCommand.Execute();
+    }
+}

--- a/Game/IoC/RegisterIoCDependencyMoveCommand.cs
+++ b/Game/IoC/RegisterIoCDependencyMoveCommand.cs
@@ -11,7 +11,7 @@ public class RegisterIoCDependencyMoveCommand : ICommand
             var obj = args[0];
 
             var adapter = Ioc.Resolve<object>("Adapters.IMovingObject", obj);
-            
+
             return new MoveCommand((IMovingObject)adapter);
         };
 


### PR DESCRIPTION
Регистрация зависимости Commands.Move в IoC.
Зарегистрировать зависимость "Commands.Move" в IoC, с помощью которой можно разрешить команду MoveCommand по игровому объекту. Для регистрации зависимости определить отдельную команду с префиксом RegisterIoCDependency:
public class RegisterIoCDependencyMoveCommand : ICommand
{
public void Execute()
{
// код, регистрирующий зависимость
}
}
Примечание: Для того, чтобы создать MoveCommand, необходимо создать адаптер IDictionary<string, object> для интерфейса IMovingObject. Задача конструирования Адаптеров по интерфейсу будет рассмотрена в другой лабораторной работе, поэтому в данной задаче используйте разрешение зависимости Ioc.Resolve("Adapters.IMovingObject", obj), где obj - игровой объект. В тестах используйте Mock-объекты, для разрешения этой зависимости.

Критерии приемки:

Реализован тест, который проверяет, что при выполнении Execute класса RegisterIoCDependencyMoveCommand зависимость разрешается.

Выполняет: Меженов Егор