### PR TITLE
feature/SendCommandIoC

### DIFF
--- a/Game.Tests/Ioc/RegisterIoCDependencySendCommandTests.cs
+++ b/Game.Tests/Ioc/RegisterIoCDependencySendCommandTests.cs
@@ -1,0 +1,40 @@
+namespace Game.Tests;
+
+using App;
+using App.Scopes;
+using Moq;
+using Xunit;
+
+public class RegisterIoCDependencySendCommandTests
+{
+    public RegisterIoCDependencySendCommandTests()
+    {
+        new InitCommand().Execute();
+        var testScope = Ioc.Resolve<object>("IoC.Scope.Create");
+        Ioc.Resolve<ICommand>("IoC.Scope.Current.Set", testScope).Execute();
+    }
+
+    [Fact]
+    public void Execute_Should_Register_SendCommand_Dependency()
+    {
+        var mockCommand = new Mock<ICommand>();
+        var mockReceiver = new Mock<IMessageReceiver>();
+        mockReceiver.Setup(r => r.CanAccept(It.IsAny<ICommand>())).Returns(true);
+
+        var commandObject = mockCommand.Object;
+        var receiverObject = mockReceiver.Object;
+
+        var registerCmd = new RegisterIoCDependencySendCommand();
+
+        registerCmd.Execute();
+
+        var resolvedCommand = Ioc.Resolve<ICommand>(
+            "Commands.Send",
+            commandObject,
+            receiverObject
+        );
+
+        Assert.NotNull(resolvedCommand);
+        Assert.IsType<SendCommand>(resolvedCommand);
+    }
+}

--- a/Game/IoC/RegisterIoCDependencySendCommand.cs
+++ b/Game/IoC/RegisterIoCDependencySendCommand.cs
@@ -1,0 +1,23 @@
+namespace Game;
+
+public class RegisterIoCDependencySendCommand : ICommand
+{
+    public void Execute()
+    {
+        Func<object[], object> strategy = (object[] args) =>
+        {
+            var command = (ICommand)args[0];
+            var receiver = (IMessageReceiver)args[1];
+
+            return new SendCommand(command, receiver);
+        };
+
+        var registerCommand = Ioc.Resolve<ICommand>(
+            "IoC.Register",
+            "Commands.Send",
+            strategy
+        );
+
+        registerCommand.Execute();
+    }
+}


### PR DESCRIPTION
Определить зависимость "Commands.Send" в IoC, которая по команде и объекту типа IMessageReceiver конструирует команду SendCommand.
Указание: Для регистрации зависимости определить команду RegisterIoCDependencySendCommand:
public class RegisterIoCDependencySendCommand : ICommand
{
public void Execute()
{
// код, регистрирующий зависимость
}
}
Критерии приемки:

Реализован тест, который проверяет, что при выполнении Execute класса RegisterDependencySendCommand зависимость разрешается.