### PR TITLE
feature/Actions.StopIoC

### DIFF
--- a/Game.Tests/Game.Tests.csproj
+++ b/Game.Tests/Game.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/Game.Tests/IoC/Actions.StartIoCTests.cs
+++ b/Game.Tests/IoC/Actions.StartIoCTests.cs
@@ -18,7 +18,7 @@ public class RegisterIoCDependencyActionsStartTests
         new RegisterIoCDependencyActionsStart().Execute();
         var mockOrder = new Mock<IDictionary<string, object>>();
 
-        var actionStart = Ioc.Resolve<ICommand>("Actions.Start", mockOrder.Object);
+        var actionStart = Ioc.Resolve<ICommand>("Actions.Start", mockOrder.Object, "Move");
 
         Assert.NotNull(actionStart);
         Assert.IsAssignableFrom<ICommand>(actionStart);

--- a/Game.Tests/IoC/Actions.StopIoCTests.cs
+++ b/Game.Tests/IoC/Actions.StopIoCTests.cs
@@ -16,14 +16,13 @@ namespace Game.Tests.IoC
         [Fact]
         public void Execute_RegistersActionsStop_ResolvesSuccessfully()
         {
-            // Arrange
             new RegisterIoCDependencyActionsStop().Execute();
             var mockOrder = new Mock<IDictionary<string, object>>();
 
-            // Act
-            var actionStop = Ioc.Resolve<ICommand>("Actions.Stop", mockOrder.Object);
 
-            // Assert
+            var actionStop = Ioc.Resolve<ICommand>("Actions.Stop", mockOrder.Object);
+            actionStop.Execute();
+
             Assert.NotNull(actionStop);
             Assert.IsType<EmptyCommand>(actionStop);
         }

--- a/Game.Tests/IoC/Actions.StopIoCTests.cs
+++ b/Game.Tests/IoC/Actions.StopIoCTests.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Moq;
+using Xunit;
+
+namespace Game.Tests.IoC
+{
+    public class RegisterIoCDependencyActionsStopTests
+    {
+        public RegisterIoCDependencyActionsStopTests()
+        {
+            new InitCommand().Execute();
+            var testScope = Ioc.Resolve<object>("IoC.Scope.Create");
+            Ioc.Resolve<ICommand>("IoC.Scope.Current.Set", testScope).Execute();
+        }
+
+        [Fact]
+        public void Execute_RegistersActionsStop_ResolvesSuccessfully()
+        {
+            // Arrange
+            new RegisterIoCDependencyActionsStop().Execute();
+            var mockOrder = new Mock<IDictionary<string, object>>();
+
+            // Act
+            var actionStop = Ioc.Resolve<ICommand>("Actions.Stop", mockOrder.Object);
+
+            // Assert
+            Assert.NotNull(actionStop);
+            Assert.IsType<EmptyCommand>(actionStop);
+        }
+    }
+}

--- a/Game.Tests/IoC/Actions.StopIoCTests.cs
+++ b/Game.Tests/IoC/Actions.StopIoCTests.cs
@@ -17,14 +17,23 @@ namespace Game.Tests.IoC
         public void Execute_RegistersActionsStop_ResolvesSuccessfully()
         {
             new RegisterIoCDependencyActionsStop().Execute();
-            var mockOrder = new Mock<IDictionary<string, object>>();
+            var gameObject = new Dictionary<string, object>();
+            var injectable = new CommandInjectableCommand();
+            gameObject["repeatableMove"] = injectable;
+            var order = new Dictionary<string, object>
+            {
+                ["GameObject"] = gameObject,
+                ["CmdType"] = "Move"
+            };
 
-
-            var actionStop = Ioc.Resolve<ICommand>("Actions.Stop", mockOrder.Object);
-            actionStop.Execute();
+            var actionStop = Ioc.Resolve<ICommand>("Actions.Stop", order);
 
             Assert.NotNull(actionStop);
-            Assert.IsType<EmptyCommand>(actionStop);
+            Assert.IsType<StopCommand>(actionStop);
+            actionStop.Execute();
+
+            var exception = Record.Exception(() => injectable.Execute());
+            Assert.Null(exception);
         }
     }
 }

--- a/Game.Tests/commands/CommandInjectableCommandTests.cs
+++ b/Game.Tests/commands/CommandInjectableCommandTests.cs
@@ -23,5 +23,12 @@ namespace Game.Tests
             var injectable = new CommandInjectableCommand();
             var ex = Assert.Throws<NullReferenceException>(() => injectable.Execute());
         }
+
+        [Fact]
+        public void Inject_ThrowsException_WhenCommandIsNull()
+        {
+            var injectable = new CommandInjectableCommand();
+            Assert.Throws<ArgumentNullException>(() => injectable.Inject(null!));
+        }
     }
 }

--- a/Game.Tests/commands/SendCommandTest.cs
+++ b/Game.Tests/commands/SendCommandTest.cs
@@ -1,0 +1,52 @@
+namespace Game.Tests;
+
+using Moq;
+using Xunit;
+
+public class SendCommandTests
+{
+    [Fact]
+    public void SendCommand_Should_Call_Receive_On_Success()
+    {
+        var commandMock = new Mock<ICommand>();
+
+        var receiverMock = new Mock<IMessageReceiver>();
+
+        receiverMock.Setup(r => r.CanAccept(It.IsAny<ICommand>())).Returns(true);
+
+        var sendCommand = new SendCommand(commandMock.Object, receiverMock.Object);
+
+        sendCommand.Execute();
+        receiverMock.Verify(r => r.Receive(commandMock.Object), Times.Once);
+    }
+
+    [Fact]
+    public void SendCommand_Should_Throw_Exception_If_Receiver_Cannot_Accept()
+    {
+        var commandMock = new Mock<ICommand>();
+        var receiverMock = new Mock<IMessageReceiver>();
+
+        receiverMock.Setup(r => r.CanAccept(It.IsAny<ICommand>())).Returns(false);
+
+        var sendCommand = new SendCommand(commandMock.Object, receiverMock.Object);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => sendCommand.Execute());
+
+        Assert.Equal("recipient is busy", exception.Message);
+        receiverMock.Verify(r => r.Receive(It.IsAny<ICommand>()), Times.Never);
+    }
+
+    [Fact]
+    public void SendCommand_Constructor_Throws_When_Command_Is_Null()
+    {
+        var receiverMock = new Mock<IMessageReceiver>();
+        Assert.Throws<ArgumentNullException>(() => new SendCommand(null, receiverMock.Object));
+    }
+
+    [Fact]
+    public void SendCommand_Constructor_Throws_When_Receiver_Is_Null()
+    {
+        var commandMock = new Mock<ICommand>();
+        Assert.Throws<ArgumentNullException>(() => new SendCommand(commandMock.Object, null));
+    }
+}

--- a/Game.Tests/commands/StartCommandTests.cs
+++ b/Game.Tests/commands/StartCommandTests.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using Moq;
+using Xunit;
+
+namespace Game.Tests
+{
+    public class StartCommandTests
+    {
+        public StartCommandTests()
+        {
+            new InitCommand().Execute();
+            var testScope = Ioc.Resolve<object>("IoC.Scope.Create");
+            Ioc.Resolve<ICommand>("IoC.Scope.Current.Set", testScope).Execute();
+            new RegisterDependencyCommandInjectableCommand().Execute();
+        }
+
+        [Fact]
+        public void Execute_StartsCommand_UsesInjectableAndSendsToReceiver()
+        {
+            var gameObject = new Dictionary<string, object>();
+            var mockBaseCommand = new Mock<ICommand>();
+            var mockRepeatableCommand = new Mock<ICommand>();
+            var mockReceiver = new Mock<IMessageReceiver>();
+
+            mockReceiver.Setup(r => r.CanAccept(It.IsAny<ICommand>())).Returns(true);
+            mockReceiver.Setup(r => r.Receive(It.IsAny<ICommand>()))
+                .Callback<ICommand>(c => c.Execute());
+
+            Ioc.Resolve<ICommand>("IoC.Register", "Commands.Move", (object[] args) => mockBaseCommand.Object).Execute();
+            Ioc.Resolve<ICommand>("IoC.Register", "Macro.Move", (object[] args) => mockRepeatableCommand.Object).Execute();
+            Ioc.Resolve<ICommand>("IoC.Register", "Game.CommandsReceiver", (object[] args) => mockReceiver.Object).Execute();
+
+            var startCommand = new StartCommand(gameObject, "Move");
+
+            startCommand.Execute();
+
+            mockReceiver.Verify(r => r.CanAccept(It.IsAny<ICommand>()), Times.Once);
+            mockReceiver.Verify(r => r.Receive(It.IsAny<ICommand>()), Times.Once);
+            mockRepeatableCommand.Verify(c => c.Execute(), Times.Once);
+            Assert.True(gameObject.TryGetValue("repeatableMove", out var stored));
+            Assert.NotNull(stored);
+            Assert.IsAssignableFrom<ICommandInjectable>(stored);
+        }
+    }
+}

--- a/Game.Tests/commands/StartCommandTests.cs
+++ b/Game.Tests/commands/StartCommandTests.cs
@@ -41,5 +41,117 @@ namespace Game.Tests
             Assert.NotNull(stored);
             Assert.IsAssignableFrom<ICommandInjectable>(stored);
         }
+
+        [Fact]
+        public void Execute_ThrowsException_WhenReceiverCannotAcceptCommand()
+        {
+            var gameObject = new Dictionary<string, object>();
+            var mockBaseCommand = new Mock<ICommand>();
+            var mockRepeatableCommand = new Mock<ICommand>();
+            var mockReceiver = new Mock<IMessageReceiver>();
+
+            mockReceiver.Setup(r => r.CanAccept(It.IsAny<ICommand>())).Returns(false);
+
+            Ioc.Resolve<ICommand>("IoC.Register", "Commands.Attack", (object[] args) => mockBaseCommand.Object).Execute();
+            Ioc.Resolve<ICommand>("IoC.Register", "Macro.Attack", (object[] args) => mockRepeatableCommand.Object).Execute();
+            Ioc.Resolve<ICommand>("IoC.Register", "Game.CommandsReceiver", (object[] args) => mockReceiver.Object).Execute();
+
+            var startCommand = new StartCommand(gameObject, "Attack");
+
+            Assert.Throws<InvalidOperationException>(() => startCommand.Execute());
+        }
+
+        [Fact]
+        public void Execute_ThrowsException_WhenReceiverThrowsOnReceive()
+        {
+            var gameObject = new Dictionary<string, object>();
+            var mockBaseCommand = new Mock<ICommand>();
+            var mockRepeatableCommand = new Mock<ICommand>();
+            var mockReceiver = new Mock<IMessageReceiver>();
+
+            mockReceiver.Setup(r => r.CanAccept(It.IsAny<ICommand>())).Returns(true);
+            mockReceiver.Setup(r => r.Receive(It.IsAny<ICommand>()))
+                .Throws(new InvalidOperationException("Receiver error"));
+
+            Ioc.Resolve<ICommand>("IoC.Register", "Commands.Shoot", (object[] args) => mockBaseCommand.Object).Execute();
+            Ioc.Resolve<ICommand>("IoC.Register", "Macro.Shoot", (object[] args) => mockRepeatableCommand.Object).Execute();
+            Ioc.Resolve<ICommand>("IoC.Register", "Game.CommandsReceiver", (object[] args) => mockReceiver.Object).Execute();
+
+            var startCommand = new StartCommand(gameObject, "Shoot");
+
+            Assert.Throws<InvalidOperationException>(() => startCommand.Execute());
+        }
+
+        [Fact]
+        public void Execute_ThrowsException_WhenCommandExecutionFails()
+        {
+            var gameObject = new Dictionary<string, object>();
+            var mockBaseCommand = new Mock<ICommand>();
+            var mockRepeatableCommand = new Mock<ICommand>();
+            var mockReceiver = new Mock<IMessageReceiver>();
+
+            mockRepeatableCommand.Setup(c => c.Execute()).Throws(new ArgumentException("Command error"));
+            mockReceiver.Setup(r => r.CanAccept(It.IsAny<ICommand>())).Returns(true);
+            mockReceiver.Setup(r => r.Receive(It.IsAny<ICommand>()))
+                .Callback<ICommand>(c => c.Execute());
+
+            Ioc.Resolve<ICommand>("IoC.Register", "Commands.Rotate", (object[] args) => mockBaseCommand.Object).Execute();
+            Ioc.Resolve<ICommand>("IoC.Register", "Macro.Rotate", (object[] args) => mockRepeatableCommand.Object).Execute();
+            Ioc.Resolve<ICommand>("IoC.Register", "Game.CommandsReceiver", (object[] args) => mockReceiver.Object).Execute();
+
+            var startCommand = new StartCommand(gameObject, "Rotate");
+
+            Assert.Throws<ArgumentException>(() => startCommand.Execute());
+        }
+
+        [Fact]
+        public void Execute_WithEmptyGameObject_StoresInjectableSuccessfully()
+        {
+            var mockRepeatableCommand = new Mock<ICommand>();
+            var mockReceiver = new Mock<IMessageReceiver>();
+
+            mockReceiver.Setup(r => r.CanAccept(It.IsAny<ICommand>())).Returns(true);
+            mockReceiver.Setup(r => r.Receive(It.IsAny<ICommand>()))
+                .Callback<ICommand>(c => c.Execute());
+
+            Ioc.Resolve<ICommand>("IoC.Register", "Commands.Defend", (object[] args) => new Mock<ICommand>().Object).Execute();
+            Ioc.Resolve<ICommand>("IoC.Register", "Macro.Defend", (object[] args) => mockRepeatableCommand.Object).Execute();
+            Ioc.Resolve<ICommand>("IoC.Register", "Game.CommandsReceiver", (object[] args) => mockReceiver.Object).Execute();
+
+            var gameObject = new Dictionary<string, object>();
+            var startCommand = new StartCommand(gameObject, "Defend");
+
+            startCommand.Execute();
+
+            Assert.True(gameObject.TryGetValue("repeatableDefend", out var stored));
+            Assert.NotNull(stored);
+        }
+
+        [Fact]
+        public void Execute_StoredInjectableIsExecutable()
+        {
+            var gameObject = new Dictionary<string, object>();
+            var mockBaseCommand = new Mock<ICommand>();
+            var mockRepeatableCommand = new Mock<ICommand>();
+            var mockReceiver = new Mock<IMessageReceiver>();
+
+            mockReceiver.Setup(r => r.CanAccept(It.IsAny<ICommand>())).Returns(true);
+            mockReceiver.Setup(r => r.Receive(It.IsAny<ICommand>()))
+                .Callback<ICommand>(c => c.Execute());
+
+            Ioc.Resolve<ICommand>("IoC.Register", "Commands.Heal", (object[] args) => mockBaseCommand.Object).Execute();
+            Ioc.Resolve<ICommand>("IoC.Register", "Macro.Heal", (object[] args) => mockRepeatableCommand.Object).Execute();
+            Ioc.Resolve<ICommand>("IoC.Register", "Game.CommandsReceiver", (object[] args) => mockReceiver.Object).Execute();
+
+            var startCommand = new StartCommand(gameObject, "Heal");
+            startCommand.Execute();
+
+            var stored = (ICommand)gameObject["repeatableHeal"];
+            var newCommand = new Mock<ICommand>();
+            ((ICommandInjectable)stored).Inject(newCommand.Object);
+            stored.Execute();
+
+            newCommand.Verify(c => c.Execute(), Times.Once);
+        }
     }
 }

--- a/Game.Tests/commands/StopCommandTests.cs
+++ b/Game.Tests/commands/StopCommandTests.cs
@@ -1,0 +1,31 @@
+using Moq;
+using Xunit;
+
+namespace Game.Tests
+{
+    public class StopCommandTests
+    {
+        [Fact]
+        public void Execute_ReplacesInjectedCommandWithEmptyCommand()
+        {
+            var injectable = new CommandInjectableCommand();
+            var mockPreviousCommand = new Mock<ICommand>();
+            mockPreviousCommand.Setup(c => c.Execute()).Throws(new InvalidOperationException("Should not be executed"));
+
+            injectable.Inject(mockPreviousCommand.Object);
+            var stopCommand = new StopCommand(injectable);
+
+            stopCommand.Execute();
+
+            var exception = Record.Exception(() => injectable.Execute());
+            Assert.Null(exception);
+            mockPreviousCommand.Verify(c => c.Execute(), Times.Never);
+        }
+
+        [Fact]
+        public void Execute_ThrowsWhenInjectableIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new StopCommand(default!));
+        }
+    }
+}

--- a/Game/Game.csproj
+++ b/Game/Game.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Game/IMessageReceiver.cs
+++ b/Game/IMessageReceiver.cs
@@ -1,0 +1,7 @@
+namespace Game;
+
+public interface IMessageReceiver
+{
+    public void Receive(ICommand cmd);
+    bool CanAccept(ICommand command);
+}

--- a/Game/IoC/Actions.StartIoC.cs
+++ b/Game/IoC/Actions.StartIoC.cs
@@ -3,7 +3,14 @@ public class RegisterIoCDependencyActionsStart : ICommand
     public void Execute()
     {
         Ioc.Resolve<ICommand>("IoC.Register", "Actions.Start",
-            (object[] args) => Ioc.Resolve<ICommand>("Commands.Macro", args[0])
+            (object[] args) =>
+            {
+                var gameObject = (IDictionary<string, object>)args[0];
+                var cmdType = (string)args[1];
+
+                return new StartCommand(gameObject, cmdType);
+            }
+
         ).Execute();
     }
 }

--- a/Game/IoC/Actions.StopIoC.cs
+++ b/Game/IoC/Actions.StopIoC.cs
@@ -1,0 +1,9 @@
+public class RegisterIoCDependencyActionsStop : ICommand
+{
+    public void Execute()
+    {
+        Ioc.Resolve<ICommand>("IoC.Register", "Actions.Stop",
+            (object[] args) => new EmptyCommand()
+        ).Execute();
+    }
+}

--- a/Game/IoC/Actions.StopIoC.cs
+++ b/Game/IoC/Actions.StopIoC.cs
@@ -3,7 +3,14 @@ public class RegisterIoCDependencyActionsStop : ICommand
     public void Execute()
     {
         Ioc.Resolve<ICommand>("IoC.Register", "Actions.Stop",
-            (object[] args) => new EmptyCommand()
+            (object[] args) =>
+            {
+                var order = (IDictionary<string, object>)args[0];
+                var gameObject = (IDictionary<string, object>)order["GameObject"];
+                var cmdType = (string)order["CmdType"];
+                var injectable = (ICommandInjectable)gameObject[$"repeatable{cmdType}"];
+                return new StopCommand(injectable);
+            }
         ).Execute();
     }
 }

--- a/Game/commands/CommandInjectableCommand.cs
+++ b/Game/commands/CommandInjectableCommand.cs
@@ -1,14 +1,14 @@
 public class CommandInjectableCommand : ICommand, ICommandInjectable
 {
-    private ICommand _injectedCommand;
+    private ICommand? _injectedCommand;
 
     public void Inject(ICommand command)
     {
-        _injectedCommand = command;
+        _injectedCommand = command ?? throw new ArgumentNullException(nameof(command));
     }
 
     public void Execute()
     {
-        _injectedCommand.Execute();
+        _injectedCommand!.Execute();
     }
 }

--- a/Game/commands/EmptyCommand.cs
+++ b/Game/commands/EmptyCommand.cs
@@ -1,0 +1,4 @@
+public class EmptyCommand : ICommand
+{
+    public void Execute() { }
+}

--- a/Game/commands/SendCommand.cs
+++ b/Game/commands/SendCommand.cs
@@ -1,0 +1,23 @@
+namespace Game;
+
+public class SendCommand : ICommand
+{
+    private readonly ICommand _command;
+    private readonly IMessageReceiver _receiver;
+
+    public SendCommand(ICommand command, IMessageReceiver receiver)
+    {
+        _command = command ?? throw new ArgumentNullException(nameof(command));
+        _receiver = receiver ?? throw new ArgumentNullException(nameof(receiver));
+    }
+
+    public void Execute()
+    {
+        if (!_receiver.CanAccept(_command))
+        {
+            throw new InvalidOperationException("recipient is busy");
+        }
+
+        _receiver.Receive(_command);
+    }
+}

--- a/Game/commands/StartCommand.cs
+++ b/Game/commands/StartCommand.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using Game;
+
+public class StartCommand : ICommand
+{
+    private readonly IDictionary<string, object> _gameObject;
+    private readonly string _cmdType;
+
+    public StartCommand(IDictionary<string, object> gameObject, string cmdType)
+    {
+        _gameObject = gameObject;
+        _cmdType = cmdType;
+    }
+
+    public void Execute()
+    {
+        var cmd = Ioc.Resolve<ICommand>($"Commands.{_cmdType}", _gameObject);
+        var injectable = (ICommand)Ioc.Resolve<ICommandInjectable>("Commands.CommandInjectable");
+        var receiver = Ioc.Resolve<IMessageReceiver>("Game.CommandsReceiver");
+        var send = new SendCommand(injectable, receiver);
+        var repeatable = Ioc.Resolve<ICommand>($"Macro.{_cmdType}", cmd, send);
+        ((ICommandInjectable)injectable).Inject(repeatable);
+        _gameObject[$"repeatable{_cmdType}"] = injectable;
+        var sendCommand = new SendCommand(repeatable, receiver);
+        sendCommand.Execute();
+    }
+}

--- a/Game/commands/StopCommand.cs
+++ b/Game/commands/StopCommand.cs
@@ -1,0 +1,17 @@
+using System;
+using Game;
+
+public class StopCommand : ICommand
+{
+    private readonly ICommandInjectable _injectable;
+
+    public StopCommand(ICommandInjectable injectable)
+    {
+        _injectable = injectable ?? throw new ArgumentNullException(nameof(injectable));
+    }
+
+    public void Execute()
+    {
+        _injectable.Inject(new EmptyCommand());
+    }
+}


### PR DESCRIPTION
Определить зависимость "Actions.Stop" для запуска длительной операции.
Необходимо так определить зависимость, чтобы следующий код позволял получать команду:
IDictionary<string, object> order = ...; // приказ об остановке длительной операции
Ioc.Resolve("Actions.Stop", order);
Сама регистрация зависимости должна быть выполнена в команде RegisterIoCDepenedncyActionsStop

public class RegisterIoCDependencyActionsStop : ICommand
{
public void Execute()
{
// здесь код для регистрации зависимостей
}
}
Критерии приемки:

Реализован тест, который проверяет, что при выполнении Execute класса RegisterIoCDependencyActionsStop зависимость разрешается.
Остановка команды выполняется за константное время.